### PR TITLE
Fix: Correct missing comma and grammar errors in README examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ circle.addEntry({
 });
 ```
 
-The call `start` to start the animation.
+Call the `start()` method to begin the animation.
 
 ```javascript
 circle.start(33); // 33 is the interval(ms) between each update

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ var circle = new ProgressCircle({
 
 circle.addEntry({
     fillColor: 'rgba(255, 255, 0, 0.5)',
-    outlineColor: 'rgba(255, 255, 255, 0.5)' // (Optional)
+    outlineColor: 'rgba(255, 255, 255, 0.5)', // (Optional)
     progressListener: function() {return p1;},
     infoListener: function() {return text1;},// (Optional)
 });


### PR DESCRIPTION
This PR fixes two documentation issues in the README:

1. **Missing comma in example code**
   The `outlineColor` line in the optional parameters example was missing a trailing comma:

   Incorrect:
   outlineColor: 'rgba(255, 255, 255, 0.5)' // (Optional)

   Corrected:
   outlineColor: 'rgba(255, 255, 255, 0.5)', // (Optional)

   Without this comma, the example produces invalid JavaScript when copied by users.

2. **Grammar fix in method usage instructions**
   The sentence "The call start to start the animation." was replaced with:
   "Call the `start()` method to begin the animation."

These fixes improve clarity and correctness for users following the documentation.


